### PR TITLE
Revert "Add cxxmodules to PR build"

### DIFF
--- a/src/cern/root/pipeline/BuildConfiguration.groovy
+++ b/src/cern/root/pipeline/BuildConfiguration.groovy
@@ -58,7 +58,6 @@ class BuildConfiguration {
     static def getPullrequestConfiguration(extraCMakeOptions) {
         return [
             [ label: 'slc6',      compiler: 'gcc48',   buildType: 'Release', opts: ''                   + ' ' + extraCMakeOptions ],
-            [ label: 'slc6',      compiler: 'clang_gcc62', buildType: 'Release', opts: '-Dcxxmodules=ON'+ ' ' + extraCMakeOptions ],
             [ label: 'slc6-i686', compiler: 'gcc49',   buildType: 'Release', opts: ''                   + ' ' + extraCMakeOptions ],
             [ label: 'centos7',   compiler: 'clang39', buildType: 'Release', opts: ''                   + ' ' + extraCMakeOptions ],
             [ label: 'centos7',   compiler: 'gcc62',   buildType: 'Release', opts: '-Dcxx14=ON'         + ' ' + extraCMakeOptions ],


### PR DESCRIPTION
This reverts commit 5ea936e762a987bb44f445e2a0478c6324d3cca9.

PR builds caused a test failure which was not visible in nightles. 