### PR TITLE
Old broken clang 3.9 is removed from PRs

### DIFF
--- a/src/cern/root/pipeline/BuildConfiguration.groovy
+++ b/src/cern/root/pipeline/BuildConfiguration.groovy
@@ -61,7 +61,6 @@ class BuildConfiguration {
             [ label: 'slc6',      compiler: 'gcc48',   buildType: 'Release', opts: ''                   + ' ' + extraCMakeOptions ],
             [ label: 'slc6',      compiler: 'gcc62',   buildType: 'Release', opts: '-Druntime_cxxmodules=ON' + ' ' + extraCMakeOptions ],
             [ label: 'slc6-i686', compiler: 'gcc49',   buildType: 'Release', opts: ''                   + ' ' + extraCMakeOptions ],
-            [ label: 'centos7',   compiler: 'clang39', buildType: 'Release', opts: ''                   + ' ' + extraCMakeOptions ],
             [ label: 'centos7',   compiler: 'gcc62',   buildType: 'Release', opts: '-Dcxx14=ON'         + ' ' + extraCMakeOptions ],
             [ label: 'centos7',   compiler: 'gcc7',    buildType: 'Release', opts: '-Dcxx17=ON'         + ' ' + extraCMakeOptions ],
             [ label: 'fedora28',  compiler: 'native',  buildType: 'Release', opts: '-Dpython_version=3' + ' ' + extraCMakeOptions ],


### PR DESCRIPTION
Builds with clang 3.9 have Vc warnings and references of filemerger test are unexplainably few bytes bigger, while other compilers provide stable statistics