### PR TITLE
Remove cxx14 from windows10 default spec

### DIFF
--- a/src/cern/root/pipeline/BuildConfiguration.groovy
+++ b/src/cern/root/pipeline/BuildConfiguration.groovy
@@ -63,7 +63,7 @@ class BuildConfiguration {
             [ label: 'ROOT-ubuntu2004',  opts: extraCMakeOptions, spec: 'python3' ],
             [ label: 'mac11',   opts: extraCMakeOptions, spec: 'noimt' ],
             [ label: 'mac12arm',   opts: extraCMakeOptions + ' -DCTEST_TEST_EXCLUDE_NONE=On', spec: 'cxx20' ],
-            [ label: 'windows10', opts: extraCMakeOptions, spec: 'cxx14' ]
+            [ label: 'windows10', opts: extraCMakeOptions, spec: 'default']
         ]
     }
 


### PR DESCRIPTION
With the move to C++17 as the minimum standard for ROOT we should not build windows with cxx14. In fact, the 'spec' attribute is changed to 'default'.